### PR TITLE
feat: ignore all non-F/f/T/t inputs

### DIFF
--- a/src/script.js
+++ b/src/script.js
@@ -127,7 +127,10 @@ window.onload = () => {
 
 	const addMovement = () => {
 		const directions = commands.value.split('');
-		directions.map(direction => movements.push(direction.toLowerCase() === 'f' ? "forward" : "turn"));
+		directions.map(direction => {
+			if (direction.toLowerCase() === 'f') movements.push("forward");
+			if (direction.toLowerCase() === 't') movements.push("turn");
+		});
 	}
 
 	const checkPosition = (index) => {


### PR DESCRIPTION
## 問題点
- 受講生のチャットをコピー&ペーストした際、`F`,`f`,`T`,`t`以外の意図しない指示により矢印が回転してしまう
- `F`,`f`,`T`,`t`以外の意図しない指示を手入力できないようになっているが、コピー&ペーストできてしまう
- レクチャー中は、手入力ではなく受講生の回答をコピー&ペーストするので、改善したい
(例)
1. `FFEFEEEFEEEFEFEEEFEFEFFEEEFEFEEEFEEEFFEF`
  -> `E`で回転してしまう 
2. `FF T F TTT F TTT F T F TTT F T F T FF TTT F T F TTT F TTT FF T F`
  -> ` `で回転してしまう
3. `FF,T,F,TTT,F,TTT,F,T,F,TTT,F,T,F,T,FF,TTT,F,T,F,TTT,F,TTT,FF,T,F`
  -> `,`で回転してしまう

## 対応内容
- `F`,`f`,`T`,`t`以外は無視して次の指示を実行するようにする

## 確認内容

`F f,EFetT` を入力して `FFFTT` と同じ動きになることを確認済み


Closed codechrysalis/dig-community#54